### PR TITLE
Fix Relto Issues

### DIFF
--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.cpp
@@ -1721,12 +1721,12 @@ PyObject* PythonInterface::FindModule(const char* module)
 //
 //  Returns    : True if unique , otherwise returns False
 //
-bool PythonInterface::IsModuleNameUnique(char* module)
+bool PythonInterface::IsModuleNameUnique(const ST::string& module)
 {
     PyObject *m;
     // first we must get rid of any old modules of the same name, we'll replace it
     PyObject *modules = PyImport_GetModuleDict();
-    if ((m = PyDict_GetItemString(modules, module)) != NULL && PyModule_Check(m))
+    if ((m = PyDict_GetItemString(modules, module.c_str())) != NULL && PyModule_Check(m))
     {
         return false;
     }

--- a/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
+++ b/Sources/Plasma/FeatureLib/pfPython/cyPythonInterface.h
@@ -47,6 +47,7 @@ You can contact Cyan Worlds, Inc. by email legal@cyan.com
 //       only be one instance of this interface. 
 //
 #include "HeadSpin.h"
+#include <string_theory/string>
 #include <string>
 #include <vector>
 
@@ -143,7 +144,7 @@ public:
     static PyObject* GetPlasmaItem(char* item);
 
     // Determine if the module name is unique
-    static bool IsModuleNameUnique(char* module);
+    static bool IsModuleNameUnique(const ST::string& module);
     // get an item (probably a function) from a specific module
     static PyObject* GetModuleItem(char* item, PyObject* module);
 

--- a/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/plPythonFileMod.cpp
@@ -961,39 +961,16 @@ void    plPythonFileMod::HandleDiscardedKey( plKeyEventMsg *msg )
 //
 ST::string plPythonFileMod::IMakeModuleName(plSceneObject* sobj)
 {
-    // Forgive my general crapulance...
-    // This strips underscores out of module names 
-    // so python won't truncate them... -S
+    // This strips underscores out of module names so python won't truncate them... -S
 
     plKey pKey = GetKey();
     plKey sKey = sobj->GetKey();
 
-    const char* pKeyName = pKey->GetName().c_str();
-    const char* pSobjName = sKey->GetName().c_str();
+    ST::string soName = sKey->GetName().replace("_", "");
+    ST::string pmName = pKey->GetName().replace("_", "");
 
-    uint16_t len = pKey->GetName().size();
-    uint16_t slen = sKey->GetName().size();
-
-    hsAssert(len+slen < 256, "Warning: String length exceeds 256 characters.");
-    char modulename[256];
-    
-    int i, k = 0;
-    for(i = 0; i < slen; i++)
-    {
-        if(pSobjName[i] == '_') continue;
-
-        modulename[k++] = pSobjName[i];
-    }
-    for(i = 0; i < len; i++)
-    {
-        if(pKeyName[i] == '_') continue;
-
-        modulename[k++] = pKeyName[i];
-    }
-
-    modulename[k] = '\0';
     ST::string_stream name;
-    name << modulename;
+    name << soName << pmName;
 
     // check to see if we are attaching to a clone?
     plKeyImp* pKeyImp = (plKeyImp*)(sKey);
@@ -1008,7 +985,7 @@ ST::string plPythonFileMod::IMakeModuleName(plSceneObject* sobj)
     }
 
     // make sure that the actual modulue will be uniqie
-    if ( !PythonInterface::IsModuleNameUnique(modulename) )
+    if ( !PythonInterface::IsModuleNameUnique(name.to_string()))
     {
         // if not unique then add the sequence number to the end of the modulename
         uint32_t seqID = pKeyImp->GetUoid().GetLocation().GetSequenceNumber();

--- a/Sources/Plasma/FeatureLib/pfPython/pyKey.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKey.cpp
@@ -94,9 +94,9 @@ bool pyKey::operator==(const pyKey &key) const
         return false;
 }
 
-const char* pyKey::getName() const
+ST::string pyKey::getName() const
 {
-    return fKey ? fKey->GetName().c_str() : "nil";
+    return fKey ? fKey->GetName() : "nil";
 }
 
 #ifndef BUILDING_PYPLASMA

--- a/Sources/Plasma/FeatureLib/pfPython/pyKey.h
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKey.h
@@ -95,7 +95,7 @@ public:
     // getter and setters
     virtual plKey getKey() { return fKey; }
     virtual void setKey(plKey key) { fKey=key; }
-    virtual const char* getName() const;
+    virtual ST::string getName() const;
 #ifndef BUILDING_PYPLASMA
     PyObject* GetPySceneObject();
 

--- a/Sources/Plasma/FeatureLib/pfPython/pyKeyGlue.cpp
+++ b/Sources/Plasma/FeatureLib/pfPython/pyKeyGlue.cpp
@@ -104,7 +104,7 @@ PYTHON_METHOD_DEFINITION(ptKey, netForce, args)
 
 PYTHON_METHOD_DEFINITION_NOARGS(ptKey, getName)
 {
-    return PyString_FromString(self->fThis->getName());
+    return PyString_FromSTString(self->fThis->getName());
 }
 
 PYTHON_BASIC_METHOD_DEFINITION(ptKey, enable, Enable)


### PR DESCRIPTION
This changeset fixes some occasional crashes seen in the Python module name hacking. It also fixes the issue of the Relto bookshelf not working correctly--ptKey.getName() was returning empty string objects. There are still some odd crashes that are coming up every so often. One particularly troublesome one appears to be a garbage log message in plResponderModifier, but I didn't feel like chasing that down.